### PR TITLE
fix: vercel error

### DIFF
--- a/puppeteer.config.js
+++ b/puppeteer.config.js
@@ -1,0 +1,8 @@
+const { join } = require("node:path");
+const os = require("node:os");
+const { Configuration } = require("puppeteer");
+
+/** @type {Configuration} */
+module.exports = {
+  cacheDirectory: join(os.homedir(), ".cache", "puppeteer")
+}


### PR DESCRIPTION
I believe the 'Could not find Chromium (rev. 1108766).' vercel error has been fixed with this commit